### PR TITLE
Master error on upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ misc/
 dist/
 Icon?
 node_modules/
+nbproject/

--- a/lib.php
+++ b/lib.php
@@ -24,6 +24,11 @@ function local_akindi_extend_navigation_course($navigation, $course, $context) {
   }
 }
 
+/**
+ * This function gets the possible student id numbers
+ * to use for identification on the akindi forms.
+ * 
+ */
 function ak_settings_get_student_id_options() {
   $options = array(
     'idnumber'=>"ID number (idnumber)",

--- a/lib.php
+++ b/lib.php
@@ -23,3 +23,15 @@ function local_akindi_extend_navigation_course($navigation, $course, $context) {
       
   }
 }
+
+function ak_settings_get_student_id_options() {
+  $options = array(
+    'idnumber'=>"ID number (idnumber)",
+    'userid'=>"Moodle user id (userid)",
+  );
+  $customfields = profile_get_custom_fields();
+  foreach ($customfields as $field) {
+    $options[$field->shortname] = "{$field->name} ({$field->shortname})";
+  }
+  return $options;
+}

--- a/settings.php
+++ b/settings.php
@@ -1,6 +1,8 @@
 <?php
 
 if ( $hassiteconfig ){
+  require_once("$CFG->dirroot/local/akindi/lib.php");
+  
   $settings = new admin_settingpage('local_akindi', 'Akindi Settings');
   $ADMIN->add('localplugins', $settings);
 

--- a/settings.php
+++ b/settings.php
@@ -1,17 +1,5 @@
 <?php
 
-function ak_settings_get_student_id_options() {
-  $options = array(
-    'idnumber'=>"ID number (idnumber)",
-    'userid'=>"Moodle user id (userid)",
-  );
-  $customfields = profile_get_custom_fields();
-  foreach ($customfields as $field) {
-    $options[$field->shortname] = "{$field->name} ({$field->shortname})";
-  }
-  return $options;
-}
-
 if ( $hassiteconfig ){
   $settings = new admin_settingpage('local_akindi', 'Akindi Settings');
   $ADMIN->add('localplugins', $settings);


### PR DESCRIPTION
Hi David,
This is Matt Switlik over at Oakland University. I was upgrading our plugin to v20161219 and ran into an error when the instance of moodle was upgraded from v3.1 to v3.2.  The problem is the settings.php file is loaded more that once and throws a "can not redeclare function ak_settings_get_student_id_options" error. Apparently in moodle's architecture a settings.php file can't have functions. So I moved the function to lib.php and added a call to require_once().