### PR TITLE
MAE-3389: Sanitize itemid prior to DB query.

### DIFF
--- a/testing.php
+++ b/testing.php
@@ -114,7 +114,8 @@ function ak_test_action_setup() {
 
 function ak_test_action_get_grades() {
   global $DB;
-  return $DB->get_records('grade_grades',array('itemid'=>$_GET["itemid"]));
+  $cleaned_itemid = required_param($_GET["itemid"], PARAM_INT);
+  return $DB->get_records('grade_grades',array('itemid'=>$cleaned_itemid));
 }
 
 function ak_test_run() {


### PR DESCRIPTION
Added code to ensure value is sanitized when being retrieved from $_GET.  Note that if for some reason this value is _not_ mandatory then it could be switched to optional_param instead.