### PR TITLE
Moodle Student Launch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Installation
      account access to LMS integration options).
 
   b. Click "Add LMS Integration" and fill out the form. Make sure that the
-     *LMS URL* field beings with ``https://`` and contains the complete
+     *LMS URL* field begins with ``https://`` and contains the complete
      path to the location Akindi's local plugin will be installed. The URL is
      usually similar to
      ``https://moodle.yourschool.com/moodle/local/akindi``.

--- a/api.php
+++ b/api.php
@@ -11,11 +11,10 @@ require_once("$CFG->dirroot/user/profile/lib.php");
 
 function ak_get_validate_course_id($action) {
   global $AK_USER_ID;
-  global $CFG;
 
   $course_id = ak_get($action, 'course_id');
   $context = context_course::instance($course_id);
-  if (!$CFG->akindi_enable_student_launch && !has_capability('moodle/grade:edit', $context, $user=$AK_USER_ID))
+  if (!has_capability('moodle/grade:edit', $context, $user=$AK_USER_ID))
     throw new moodle_exception("no-permission:$AK_USER_ID-in-$course_id", 'akindi');
   return $course_id;
 }

--- a/api.php
+++ b/api.php
@@ -11,10 +11,11 @@ require_once("$CFG->dirroot/user/profile/lib.php");
 
 function ak_get_validate_course_id($action) {
   global $AK_USER_ID;
+  global $CFG;
 
   $course_id = ak_get($action, 'course_id');
   $context = context_course::instance($course_id);
-  if (!has_capability('moodle/grade:edit', $context, $user=$AK_USER_ID))
+  if (!$CFG->akindi_enable_student_launch && !has_capability('moodle/grade:edit', $context, $user=$AK_USER_ID))
     throw new moodle_exception("no-permission:$AK_USER_ID-in-$course_id", 'akindi');
   return $course_id;
 }

--- a/launch.php
+++ b/launch.php
@@ -63,6 +63,8 @@ $data_str = json_encode(array(
     'first'=>$USER->firstname,
     'last'=>$USER->lastname,
     'key'=>ak_sign($CFG->akindi_instance_secret, $USER->id),
+    // We will use this to determine whether we should launch as an instructor or student.
+    'has_edit_grade_capability'=>has_capability('moodle/grade:edit', $context, $user=$USER->id)
   ),
   'course'=>array(
     'id'=>$course->id,

--- a/launch.php
+++ b/launch.php
@@ -21,7 +21,10 @@ $PAGE->set_title(get_string('launching', 'local_akindi'));
 $PAGE->navbar->add(get_string('pluginname', 'local_akindi'));
 echo $OUTPUT->header();
 
-if (!has_capability('moodle/grade:edit', $context)) {
+global $CFG;
+global $USER;
+
+if (!$CFG->akindi_enable_student_launch && !has_capability('moodle/grade:edit', $context)) {
   ?>
 
   <h2>Permission Denied</h2>
@@ -31,9 +34,6 @@ if (!has_capability('moodle/grade:edit', $context)) {
   echo $OUTPUT->footer();
   die();
 }
-
-global $CFG;
-global $USER;
 
 $required_settings = array(
   'akindi_launch_url',

--- a/lib.php
+++ b/lib.php
@@ -15,7 +15,7 @@ require_once("$CFG->dirroot/user/profile/lib.php");
  */
 function local_akindi_extend_navigation_course($navigation, $course, $context) {
   global $CFG;
-  if (!has_capability('moodle/grade:edit', $context))
+  if (!$CFG->akindi_enable_student_launch && !has_capability('moodle/grade:edit', $context))
     return;
 
   $url = new moodle_url('/local/akindi/launch.php', array('id'=>$course->id));
@@ -27,7 +27,8 @@ function local_akindi_extend_navigation_course($navigation, $course, $context) {
  */
 function local_akindi_extends_settings_navigation($navigation, $context) {
   global $PAGE;
-  if (!has_capability('moodle/grade:edit', $context))
+  global $CFG;
+  if (!$CFG->akindi_enable_student_launch && !has_capability('moodle/grade:edit', $context))
     return;
 
   $settingnode = $navigation->find('courseadmin', navigation_node::TYPE_COURSE);

--- a/settings.php
+++ b/settings.php
@@ -54,6 +54,14 @@ if ( $hassiteconfig ){
     false,
     PARAM_BOOL
   ));
+
+  $settings->add(new admin_setting_configcheckbox(
+    'akindi_enable_student_launch',
+    'Enable student launch',
+    'Makes the "Launch Akindi" link available to students so they can access their online assessments via Moodle.',
+    false,
+    PARAM_BOOL
+  ));
 }
 
 ?>


### PR DESCRIPTION
These changes to our Moodle plugin are required to support students launching Akindi from Moodle.

**This PR does 3 things:**
1. Adds a new setting to enable student launch
2. Don't block students launching if that setting is enabled
3. During launch, send enough information to Akindi to be able to determine if we should launch Akindi as a student or instructor
- We send whether this user has the capability to edit grades. This is a proxy, but the capabilities system is deemed more reliable and Moodle-esque than relying on the role system
